### PR TITLE
Use a struct initialiser as the API

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"log"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/go-fsnotify/fsevents"
@@ -20,9 +21,10 @@ func main() {
 		//		Device:  dev,
 		Flags: fsevents.FileEvents | fsevents.WatchRoot}
 	es.Start()
+	ec := es.Events
 
 	go func() {
-		for msg := range es.Events {
+		for msg := range ec {
 			for _, event := range msg {
 				logEvent(event)
 			}
@@ -31,18 +33,26 @@ func main() {
 
 	in := bufio.NewReader(os.Stdin)
 
-	log.Print("Started, press enter to stop")
-	in.ReadString('\n')
-	es.Stop()
+	if false {
+		log.Print("Started, press enter to GC")
+		in.ReadString('\n')
+		runtime.GC()
+		log.Print("GC'd, press enter to quit")
+		in.ReadString('\n')
+	} else {
+		log.Print("Started, press enter to stop")
+		in.ReadString('\n')
+		es.Stop()
 
-	log.Print("Stopped, press enter to restart")
-	in.ReadString('\n')
-	es.Resume = true
-	es.Start()
+		log.Print("Stopped, press enter to restart")
+		in.ReadString('\n')
+		es.Resume = true
+		es.Start()
 
-	log.Print("Restarted, press enter to quit")
-	in.ReadString('\n')
-	es.Stop()
+		log.Print("Restarted, press enter to quit")
+		in.ReadString('\n')
+		es.Stop()
+	}
 }
 
 var noteDescription = map[fsevents.EventFlags]string{


### PR DESCRIPTION
This is a first cut at a sensible API:

Create an EventStream, like so:

``` go
    es := &fsevents.EventStream{
        Paths:   []string{"/tmp"},
        Latency: 500 * time.Millisecond,
        //      Device:  dev,
        Flags: fsevents.FileEvents | fsevents.WatchRoot}
```

Start it:

``` go
   es.Start()
```

It will create a channel at `es.Events`, or use the one supplied, to publish incoming events.

When done, or after making changes to things like `es.Paths` Stop the stream (and optionally restart it).

The only other (useful) method is `es.Flush` which causes any pending events (caused by `Latency` option) to be delivered now.

@nathany let me know what you think. Also, the code in `FSEventsSince` should probably be removed, and put in an example?
