### PR TITLE
call runtime.LockOSThread

### DIFF
--- a/fsevents.go
+++ b/fsevents.go
@@ -214,6 +214,7 @@ func (es *EventStream) Start() {
 	}
 
 	go func() {
+		runtime.LockOSThread()
 		es.rlref = C.CFRunLoopGetCurrent()
 		C.FSEventStreamScheduleWithRunLoop(es.stream, es.rlref, C.kCFRunLoopDefaultMode)
 		C.FSEventStreamStart(es.stream)


### PR DESCRIPTION
This is to ensure that the goroutine doesn't switch OS threads before it calls CFRunLoopRun. I've seen issues with this before when using CFRunLoopStop/CFRunLoopRun multiple times. Since the current code only calls Run once, It's possible it will never run into issues but this seems like an easy defensive change.
