### PR TITLE
change chan []Event to buffered chan Event

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -26,8 +26,9 @@ func main() {
 	ec := es.Events
 
 	go func() {
-		for msg := range ec {
-			for _, event := range msg {
+		for {
+			select {
+			case event := <-ec:
 				logEvent(event)
 			}
 		}


### PR DESCRIPTION
I had to add ``es.Flush`` in order to get this to work. I run into jammed buffers otherwise. 

```go
	go func() {
		for {
			select {
			case event := <-ec:
				logEvent(event)
				es.Flush(false)
			}
		}
	}()
```

Could we enable "issues" for this repo?