### PR TITLE
license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2014 The fsevents Authors. All rights reserved.
+Copyright (c) 2016, The fsnotify Authors.
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -10,9 +11,6 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FSEvents bindings for Go (macOS)
 
-[![GoDoc](https://godoc.org/github.com/fsnotify/fsevents?status.svg)](https://godoc.org/github.com/fsnotify/fsevents)
+[![GoDoc](https://godoc.org/github.com/fsnotify/fsevents?status.svg)](https://godoc.org/github.com/fsnotify/fsevents) ![Simplified BSD](https://img.shields.io/badge/license-BSD-blue.svg)
 
 [FSEvents](https://developer.apple.com/library/mac/documentation/Darwin/Reference/FSEvents_Ref/) allows an application to monitor a whole file system or portion of it. FSEvents is only available on macOS.
 


### PR DESCRIPTION
#### What does this pull request do?

Modifies the LICENSE file and adds a badge to the [README](https://github.com/fsnotify/fsevents/tree/license).

fsevents isn't a Google project, nor does it contain code that was contributed to Google (afaik) -- @samjacobson contributed the initial implementation.

Is a simplified BSD license okay with everyone or is there another preference? [MIT](http://choosealicense.com/licenses/mit/)?

Also, no plans to have a Google CLA requirement. Though perhaps a [CLA check](https://www.clahub.com/) is worth considering?

#### Where should the reviewer start?

LICENSE file
