### PR TITLE
EventIDs are not uint32

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -152,9 +152,9 @@ func cfStringToGoString(cfs C.CFStringRef) string {
 type CFRunLoopRef C.CFRunLoopRef
 
 // EventIDForDeviceBeforeTime returns an event ID before a given time.
-func EventIDForDeviceBeforeTime(dev int32, before time.Time) uint32 {
+func EventIDForDeviceBeforeTime(dev int32, before time.Time) uint64 {
 	tm := C.CFAbsoluteTime(before.Unix())
-	return uint32(C.FSEventsGetLastEventIdForDeviceBeforeTime(C.dev_t(dev), tm))
+	return uint64(C.FSEventsGetLastEventIdForDeviceBeforeTime(C.dev_t(dev), tm))
 }
 
 // createPaths accepts the user defined set of paths and returns FSEvents


### PR DESCRIPTION
#### What does this pull request do?
Fixes improper type which may silently return invalid eventIDs due to truncation.

#### Where should the reviewer start?
... line 155?

#### How should this be manually tested?
```
	dev, err := fsevents.DeviceForPath(cfg.WatchDir)
	if err != nil {
		return nil, err
	}
	tm := time.Now().Add(-time.Hour)
	tmEventID := fsevents.EventIDForDeviceBeforeTime(dev, tm)

	es := &fsevents.EventStream{
		Paths:   []string{cfg.WatchDir},
		Latency: time.Second,
		Device:  dev,
		EventID: tmEventID, // before change, cast required here
		Resume:  true,
		Flags:   fsevents.FileEvents | fsevents.WatchRoot | fsevents.IgnoreSelf,
	}
	es.Start()
```

updating type cast to match the rest of the api