### PR TITLE
example: fix lacking '%v' for go vet testing

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -16,11 +16,11 @@ import (
 func main() {
 	path, err := ioutil.TempDir("", "fsexample")
 	if err != nil {
-		log.Fatalf("Failed to create TempDir: ", err)
+		log.Fatalf("Failed to create TempDir: %v", err)
 	}
 	dev, err := fsevents.DeviceForPath(path)
 	if err != nil {
-		log.Fatalf("Failed to retrieve device for path:", err)
+		log.Fatalf("Failed to retrieve device for path: %v", err)
 	}
 	log.Print(dev)
 	log.Println(fsevents.EventIDForDeviceBeforeTime(dev, time.Now()))


### PR DESCRIPTION
For #23 and `go vet ./...` CI testing.

#### What does this pull request do?
Fix lacing `%v` which suggested `go vet ./...` test.

#### Where should the reviewer start?
@nathany suggested on https://github.com/fsnotify/fsevents/pull/23#issuecomment-259829551. I think already finished code review.
Nothing to do.

#### How should this be manually tested?
Just `go vet ./...`.