### PR TITLE
[WIP] ci/travis: fix 10.11 and 10.10 xcode images version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ matrix:
     - os: osx
       osx_image: xcode8.1 # macOS 10.12
     - os: osx
-      osx_image: xcode8   # macOS 10.11
+      osx_image: xcode7.3 # macOS 10.11
     - os: osx
-      osx_image: xcode7.1 # macOS 10.10
+      osx_image: xcode6.4 # macOS 10.10
   fast_finish: true
 
 before_script:


### PR DESCRIPTION
Retiring some OS X images from travis.
 - https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images

That change is not done yet. I will leave the merge timing to you.