### PR TITLE
Avoid race in channel creation, closes #28

### DIFF
--- a/fsevents.go
+++ b/fsevents.go
@@ -150,6 +150,9 @@ func (r *eventStreamRegistry) Delete(i uintptr) {
 
 // Start listening to an event stream.
 func (es *EventStream) Start() {
+	if es.Events == nil {
+		es.Events = make(chan []Event)
+	}
 
 	// register eventstream in the local registry for later lookup
 	// in C callback
@@ -157,9 +160,6 @@ func (es *EventStream) Start() {
 	es.registryID = cbInfo
 	es.uuid = GetDeviceUUID(es.Device)
 	es.start(es.Paths, cbInfo)
-	if es.Events == nil {
-		es.Events = make(chan []Event)
-	}
 }
 
 // Flush events that have occurred but haven't been delivered.

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -1,3 +1,32 @@
 // +build darwin
 
 package fsevents
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestBasicExample(t *testing.T) {
+	path, err := ioutil.TempDir("", "fsexample")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(path)
+
+	dev, err := DeviceForPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	es := &EventStream{
+		Paths:   []string{path},
+		Latency: 500 * time.Millisecond,
+		Device:  dev,
+		Flags:   FileEvents,
+	}
+
+	es.Start()
+}

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -5,6 +5,7 @@ package fsevents
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -29,4 +30,23 @@ func TestBasicExample(t *testing.T) {
 	}
 
 	es.Start()
+
+	wait := make(chan Event)
+	go func() {
+		for msg := range es.Events {
+			for _, event := range msg {
+				t.Logf("Event: %#v", event)
+				wait <- event
+				es.Stop()
+				return
+			}
+		}
+	}()
+
+	err = ioutil.WriteFile(filepath.Join(path, "example.txt"), []byte("example"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-wait
 }


### PR DESCRIPTION
See #28 for more detail, this simply avoids a race condition when the events channel is created. 
