### PR TITLE
Avoid assertion failure when using Host Device

### DIFF
--- a/fsevents.go
+++ b/fsevents.go
@@ -158,7 +158,9 @@ func (es *EventStream) Start() {
 	// in C callback
 	cbInfo := registry.Add(es)
 	es.registryID = cbInfo
-	es.uuid = GetDeviceUUID(es.Device)
+	if es.Device != 0 {
+		es.uuid = GetDeviceUUID(es.Device)
+	}
 	es.start(es.Paths, cbInfo)
 }
 


### PR DESCRIPTION
Passing a device ID of zero (Host device) to FSEventsCopyUUIDForDevice
causes the following assertion failure error to be printed to the logs:

> (FSEvents.framework) FSEventsCopyUUIDForDevice(): failed assertion 'dev > 0'

