### PR TITLE
fix for Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 sudo: false
 language: go
+os: osx
+go:
+  - "1.8.7"
+  - "1.9.4"
+  - "1.10"
+  - "stable"
 
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.1 # macOS 10.12
+      osx_image: xcode8.3 # macOS 10.12
     - os: osx
       osx_image: xcode7.3 # macOS 10.11
     - os: osx
@@ -12,7 +18,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - sw_vers
+  - if which sw_vers; then sw_vers; fi
   - go get -u github.com/golang/lint/golint
 
 script:

--- a/wrap.go
+++ b/wrap.go
@@ -35,7 +35,7 @@ import (
 )
 
 // eventIDSinceNow is a sentinel to begin watching events "since now".
-const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow + (1 << 64))
+const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow)
 
 // LatestEventID returns the most recently generated event ID, system-wide.
 func LatestEventID() uint64 {
@@ -109,14 +109,14 @@ func GetStreamRefPaths(f FSEventStreamRef) []string {
 // in the FSEvents database
 func GetDeviceUUID(deviceID int32) string {
 	uuid := C.FSEventsCopyUUIDForDevice(C.dev_t(deviceID))
-	if uuid == nil {
+	if uuid == C.CFUUIDRef(0) {
 		return ""
 	}
 	return cfStringToGoString(C.CFUUIDCreateString(nil, uuid))
 }
 
 func cfStringToGoString(cfs C.CFStringRef) string {
-	if cfs == nil {
+	if cfs == 0 {
 		return ""
 	}
 	cfStr := C.CFStringCreateCopy(nil, cfs)
@@ -173,7 +173,7 @@ func createPaths(paths []string) (C.CFArrayRef, error) {
 		defer C.free(unsafe.Pointer(cpath))
 
 		str := C.CFStringCreateWithCString(nil, cpath, C.kCFStringEncodingUTF8)
-		C.CFArrayAppendValue(cPaths, unsafe.Pointer(str))
+		C.CFArrayAppendValue(C.CFMutableArrayRef(cPaths), unsafe.Pointer(str))
 	}
 	var err error
 	if len(errs) > 0 {
@@ -229,7 +229,7 @@ func (es *EventStream) start(paths []string, callbackInfo uintptr) {
 	go func() {
 		runtime.LockOSThread()
 		es.rlref = CFRunLoopRef(C.CFRunLoopGetCurrent())
-		C.FSEventStreamScheduleWithRunLoop(es.stream, es.rlref, C.kCFRunLoopDefaultMode)
+		C.FSEventStreamScheduleWithRunLoop(es.stream, C.CFRunLoopRef(es.rlref), C.kCFRunLoopDefaultMode)
 		C.FSEventStreamStart(es.stream)
 		close(started)
 		C.CFRunLoopRun()
@@ -265,5 +265,5 @@ func stop(stream FSEventStreamRef, rlref CFRunLoopRef) {
 	C.FSEventStreamStop(stream)
 	C.FSEventStreamInvalidate(stream)
 	C.FSEventStreamRelease(stream)
-	C.CFRunLoopStop(rlref)
+	C.CFRunLoopStop(C.CFRunLoopRef(rlref))
 }

--- a/wrap_deprecated.go
+++ b/wrap_deprecated.go
@@ -35,7 +35,14 @@ import (
 )
 
 // eventIDSinceNow is a sentinel to begin watching events "since now".
-const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow + (1 << 64))
+// NOTE: Go 1.9.2 broke compatibility here, for 1.9.1 and earlier we did:
+//   uint64(C.kFSEventStreamEventIdSinceNow + (1 << 64))
+// But 1.9.2+ complains about overflow and requires:
+//   uint64(C.kFSEventStreamEventIdSinceNow)
+// There does not seem to be an easy way to rectify, so hardcoding the value
+// here from FSEvents.h:
+//   kFSEventStreamEventIdSinceNow = 0xFFFFFFFFFFFFFFFFULL
+const eventIDSinceNow = uint64(0xFFFFFFFFFFFFFFFF)
 
 // LatestEventID returns the most recently generated event ID, system-wide.
 func LatestEventID() uint64 {

--- a/wrap_deprecated.go
+++ b/wrap_deprecated.go
@@ -1,4 +1,4 @@
-// +build darwin,go1.10
+// +build darwin,!go1.10
 
 package fsevents
 
@@ -35,7 +35,7 @@ import (
 )
 
 // eventIDSinceNow is a sentinel to begin watching events "since now".
-const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow)
+const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow + (1 << 64))
 
 // LatestEventID returns the most recently generated event ID, system-wide.
 func LatestEventID() uint64 {
@@ -109,14 +109,14 @@ func GetStreamRefPaths(f FSEventStreamRef) []string {
 // in the FSEvents database
 func GetDeviceUUID(deviceID int32) string {
 	uuid := C.FSEventsCopyUUIDForDevice(C.dev_t(deviceID))
-	if uuid == C.CFUUIDRef(0) {
+	if uuid == nil {
 		return ""
 	}
 	return cfStringToGoString(C.CFUUIDCreateString(nil, uuid))
 }
 
 func cfStringToGoString(cfs C.CFStringRef) string {
-	if cfs == 0 {
+	if cfs == nil {
 		return ""
 	}
 	cfStr := C.CFStringCreateCopy(nil, cfs)
@@ -173,7 +173,7 @@ func createPaths(paths []string) (C.CFArrayRef, error) {
 		defer C.free(unsafe.Pointer(cpath))
 
 		str := C.CFStringCreateWithCString(nil, cpath, C.kCFStringEncodingUTF8)
-		C.CFArrayAppendValue(C.CFMutableArrayRef(cPaths), unsafe.Pointer(str))
+		C.CFArrayAppendValue(cPaths, unsafe.Pointer(str))
 	}
 	var err error
 	if len(errs) > 0 {
@@ -229,7 +229,7 @@ func (es *EventStream) start(paths []string, callbackInfo uintptr) {
 	go func() {
 		runtime.LockOSThread()
 		es.rlref = CFRunLoopRef(C.CFRunLoopGetCurrent())
-		C.FSEventStreamScheduleWithRunLoop(es.stream, C.CFRunLoopRef(es.rlref), C.kCFRunLoopDefaultMode)
+		C.FSEventStreamScheduleWithRunLoop(es.stream, es.rlref, C.kCFRunLoopDefaultMode)
 		C.FSEventStreamStart(es.stream)
 		close(started)
 		C.CFRunLoopRun()
@@ -265,5 +265,5 @@ func stop(stream FSEventStreamRef, rlref CFRunLoopRef) {
 	C.FSEventStreamStop(stream)
 	C.FSEventStreamInvalidate(stream)
 	C.FSEventStreamRelease(stream)
-	C.CFRunLoopStop(C.CFRunLoopRef(rlref))
+	C.CFRunLoopStop(rlref)
 }


### PR DESCRIPTION
Fixes #33  and #31.

A couple of fixes so that fsevents builds in Go 1.10. Sadly this breaks
compatibility with Go 1.9 and below, but there doesn't seem to be any
way to avoid that. I have not fully vetted it, just confirmed that it builds and the example runs.

- the `kFSEventStreamEventIdSinceNow` type is now correctly unsigned, so
the the need to convert from a signed integer is no longer needed.

- nil must be changed to 0 in a few places now.

- We must cast to the correct C type in a few places.