### PR TITLE
Fix error notification when using host mode (no device)

### DIFF
--- a/fsevents.go
+++ b/fsevents.go
@@ -158,7 +158,9 @@ func (es *EventStream) Start() {
 	// in C callback
 	cbInfo := registry.Add(es)
 	es.registryID = cbInfo
-	es.uuid = GetDeviceUUID(es.Device)
+	if es.Device != 0 {
+		es.uuid = GetDeviceUUID(es.Device)
+	}
 	es.start(es.Paths, cbInfo)
 }
 

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -10,6 +10,36 @@ import (
 	"time"
 )
 
+func newEventStream(t *testing.T, path string, useDev bool) *EventStream {
+	es := &EventStream{
+		Paths:   []string{path},
+		Latency: 500 * time.Millisecond,
+		Flags:   FileEvents,
+	}
+
+	if useDev {
+		dev, err := DeviceForPath(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		es.Device = dev
+	}
+
+	return es
+}
+
+func processEvents(t *testing.T, es *EventStream, wait chan Event) {
+	for msg := range es.Events {
+		for _, event := range msg {
+			t.Logf("Event: %#v", event)
+			wait <- event
+			es.Stop()
+			return
+		}
+	}
+}
+
 func TestBasicExample(t *testing.T) {
 	path, err := ioutil.TempDir("", "fsexample")
 	if err != nil {
@@ -17,33 +47,36 @@ func TestBasicExample(t *testing.T) {
 	}
 	defer os.RemoveAll(path)
 
-	dev, err := DeviceForPath(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	es := &EventStream{
-		Paths:   []string{path},
-		Latency: 500 * time.Millisecond,
-		Device:  dev,
-		Flags:   FileEvents,
-	}
+	es := newEventStream(t, path, true)
 
 	es.Start()
 
 	wait := make(chan Event)
-	go func() {
-		for msg := range es.Events {
-			for _, event := range msg {
-				t.Logf("Event: %#v", event)
-				wait <- event
-				es.Stop()
-				return
-			}
-		}
-	}()
+	go processEvents(t, es, wait)
 
-	err = ioutil.WriteFile(filepath.Join(path, "example.txt"), []byte("example"), 0700)
+	err = ioutil.WriteFile(filepath.Join(path, "example.txt"), []byte("example"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-wait
+}
+
+func TestNoDevice(t *testing.T) {
+	path, err := ioutil.TempDir("", "fsexample")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(path)
+
+	es := newEventStream(t, path, false)
+
+	es.Start()
+
+	wait := make(chan Event)
+	go processEvents(t, es, wait)
+
+	err = ioutil.WriteFile(filepath.Join(path, "example.txt"), []byte("example"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### Changes
- When creating an EventStream with no device (dev number is 0) there would be
  a failed assertion message to stderr. The event stream device uuid is only
  gotten if the device number if non-zero.
- Added unit test to create an event stream in host mode
- Made temp file permissions non-executable

#### What does this pull request do?
When creating an EventStream with no device (dev id 0), there would be a failed assertion message output.

```
2018-07-17 20:48 fsevents.test[21765] (FSEvents.framework) FSEventsCopyUUIDForDevice(): failed assertion 'dev > 0'
```

This pull request changes the package to only get a device uuid if the device id is non-zero.

#### How should this be manually tested?
This can be tested by running:

```
go test -v
```
