### PR TITLE
Avoid panic when using a released CFRunLoop

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -229,6 +229,7 @@ func (es *EventStream) start(paths []string, callbackInfo uintptr) {
 	go func() {
 		runtime.LockOSThread()
 		es.rlref = CFRunLoopRef(C.CFRunLoopGetCurrent())
+		C.CFRetain(C.CFTypeRef(es.rlref))
 		C.FSEventStreamScheduleWithRunLoop(es.stream, C.CFRunLoopRef(es.rlref), C.kCFRunLoopDefaultMode)
 		C.FSEventStreamStart(es.stream)
 		close(started)
@@ -266,4 +267,5 @@ func stop(stream FSEventStreamRef, rlref CFRunLoopRef) {
 	C.FSEventStreamInvalidate(stream)
 	C.FSEventStreamRelease(stream)
 	C.CFRunLoopStop(C.CFRunLoopRef(rlref))
+	C.CFRelease(C.CFTypeRef(rlref))
 }


### PR DESCRIPTION
As fsevents is saving the result of `CFRunLoopGetCurrent` and stopping
it from a separate thread, it's necessary to increase the reference
count of the returned CFRunLoopRef.

In the event that the run loop is terminated by other means, `stop`
might be working with a deallocated reference and produce a panic
(SIGSEGV).

#### What does this pull request do?

Fixes an occassional panic 

#### Where should the reviewer start?


#### How should this be manually tested?

