### PR TITLE
fsevents: improve documentation

### DIFF
--- a/fsevents.go
+++ b/fsevents.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 // Package fsevents provides file system notifications on macOS.
@@ -9,74 +10,29 @@ import (
 	"time"
 )
 
-// CreateFlags for creating a New stream.
-type CreateFlags uint32
-
-// kFSEventStreamCreateFlag...
-const (
-	// use CoreFoundation types instead of raw C types (disabled)
-	useCFTypes CreateFlags = 1 << iota
-
-	// NoDefer sends events on the leading edge (for interactive applications).
-	// By default events are delivered after latency seconds (for background tasks).
-	NoDefer
-
-	// WatchRoot for a change to occur to a directory along the path being watched.
-	WatchRoot
-
-	// IgnoreSelf doesn't send events triggered by the current process (macOS 10.6+).
-	IgnoreSelf
-
-	// FileEvents sends events about individual files, generating significantly
-	// more events (macOS 10.7+) than directory level notifications.
-	FileEvents
-)
-
-// EventFlags passed to the FSEventStreamCallback function.
-type EventFlags uint32
-
-// kFSEventStreamEventFlag...
-const (
-	// MustScanSubDirs indicates that events were coalesced hierarchically.
-	MustScanSubDirs EventFlags = 1 << iota
-	// UserDropped or KernelDropped is set alongside MustScanSubDirs
-	// to help diagnose the problem.
-	UserDropped
-	KernelDropped
-
-	// EventIDsWrapped indicates the 64-bit event ID counter wrapped around.
-	EventIDsWrapped
-
-	// HistoryDone is a sentinel event when retrieving events sinceWhen.
-	HistoryDone
-
-	// RootChanged indicates a change to a directory along the path being watched.
-	RootChanged
-
-	// Mount for a volume mounted underneath the path being monitored.
-	Mount
-	// Unmount event occurs after a volume is unmounted.
-	Unmount
-
-	// The following flags are only set when using FileEvents.
-
-	ItemCreated
-	ItemRemoved
-	ItemInodeMetaMod
-	ItemRenamed
-	ItemModified
-	ItemFinderInfoMod
-	ItemChangeOwner
-	ItemXattrMod
-	ItemIsFile
-	ItemIsDir
-	ItemIsSymlink
-)
-
 // Event represents a single file system notification.
 type Event struct {
+	// Path holds the path to the item that's changed, relative
+	// to its device's root.
+	// Use DeviceForPath to determine the absolute path that's
+	// being referred to.
 	Path  string
+
+	// Flags holds details what has happened.
 	Flags EventFlags
+
+	// ID holds the event ID.
+	//
+	// Each event ID comes from the most recent event being reported
+	// in the corresponding directory named in the EventStream.Paths field
+	// Event IDs all come from a single global source.
+	// They are guaranteed to always be increasing, usually in leaps
+	// and bounds, even across system reboots and moving drives from
+	// one machine to another. If you were to
+	// stop processing events from this stream after this event
+	// and resume processing them later from a newly-created
+	// EventStream, this is the value you would pass for the
+	// EventStream.EventID along with Resume=true.
 	ID    uint64
 }
 
@@ -98,19 +54,49 @@ func DeviceForPath(path string) (int32, error) {
 //   es.Stop()
 //   ...
 type EventStream struct {
-	stream       FSEventStreamRef
-	rlref        CFRunLoopRef
+	stream       fsEventStreamRef
+	rlref        cfRunLoopRef
 	hasFinalizer bool
 	registryID   uintptr
 	uuid         string
 
+	// Events holds the channel on which events will be sent.
+	// It's initialized by EventStream.Start if nil.
 	Events  chan []Event
+
+	// Paths holds the set of paths to watch, each
+	// specifying the root of a filesystem hierarchy to be
+	// watched for modifications.
 	Paths   []string
+
+	// Flags specifies what events to receive on the stream.
 	Flags   CreateFlags
-	EventID uint64
+
+	// Resume specifies that watching should resume from the event
+	// specified by EventID.
 	Resume  bool
+
+	// EventID holds the most recent event ID.
+	//
+	// NOTE: this is updated asynchronously by the
+	// watcher and should not be accessed while
+	// the stream has been started.
+	EventID uint64
+
+	// Latency holds the number of seconds the service should wait after hearing
+	// about an event from the kernel before passing it along to the
+	// client via its callback. Specifying a larger value may result
+	// in more effective temporal coalescing, resulting in fewer
+	// callbacks and greater overall efficiency.
 	Latency time.Duration
-	// syscall represents this with an int32
+
+	// When Device is non-zero, the watcher will watch events on the
+	// device with this ID, and the paths in the Paths field are
+	// interpreted relative to the device's root.
+	//
+	// The device ID is the same as the st_dev field from a stat
+	// structure of a file on that device or the f_fsid[0] field of
+	// a statfs structure.
 	Device int32
 }
 
@@ -148,7 +134,8 @@ func (r *eventStreamRegistry) Delete(i uintptr) {
 	delete(r.m, i)
 }
 
-// Start listening to an event stream.
+// Start listening to an event stream. This creates es.Events if it's not already
+// a valid channel.
 func (es *EventStream) Start() {
 	if es.Events == nil {
 		es.Events = make(chan []Event)
@@ -162,12 +149,14 @@ func (es *EventStream) Start() {
 	es.start(es.Paths, cbInfo)
 }
 
-// Flush events that have occurred but haven't been delivered.
+// Flush flushes events that have occurred but haven't been delivered.
+// If sync is true, it will block until all the events have been delivered,
+// otherwise it will return immediately.
 func (es *EventStream) Flush(sync bool) {
 	flush(es.stream, sync)
 }
 
-// Stop listening to the event stream.
+// Stop stops listening to the event stream.
 func (es *EventStream) Stop() {
 	if es.stream != nil {
 		stop(es.stream, es.rlref)
@@ -179,7 +168,8 @@ func (es *EventStream) Stop() {
 	es.registryID = 0
 }
 
-// Restart listening.
+// Restart restarts the event listener. This
+// can be used to change the current watch flags.
 func (es *EventStream) Restart() {
 	es.Stop()
 	es.Resume = true

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -47,6 +47,9 @@ func TestBasicExample(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	<-wait
+	select{
+	case <-wait:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
 }

--- a/wrap.go
+++ b/wrap.go
@@ -34,6 +34,198 @@ import (
 	"unsafe"
 )
 
+// CreateFlags specifies what events will be seen in an event stream.
+type CreateFlags uint32
+
+const (
+	// NoDefer sends events on the leading edge (for interactive applications).
+	// By default events are delivered after latency seconds (for background tasks).
+	//
+	// Affects the meaning of the EventStream.Latency parameter. If you specify
+	// this flag and more than latency seconds have elapsed since
+	// the last event, your app will receive the event immediately.
+	// The delivery of the event resets the latency timer and any
+	// further events will be delivered after latency seconds have
+	// elapsed. This flag is useful for apps that are interactive
+	// and want to react immediately to changes but avoid getting
+	// swamped by notifications when changes are occurring in rapid
+	// succession. If you do not specify this flag, then when an
+	// event occurs after a period of no events, the latency timer
+	// is started. Any events that occur during the next latency
+	// seconds will be delivered as one group (including that first
+	// event). The delivery of the group of events resets the
+	// latency timer and any further events will be delivered after
+	// latency seconds. This is the default behavior and is more
+	// appropriate for background, daemon or batch processing apps.
+	NoDefer = CreateFlags(C.kFSEventStreamCreateFlagNoDefer)
+
+	// WatchRoot requests notifications of changes along the path to
+	// the path(s) you're watching. For example, with this flag, if
+	// you watch "/foo/bar" and it is renamed to "/foo/bar.old", you
+	// would receive a RootChanged event. The same is true if the
+	// directory "/foo" were renamed. The event you receive is a
+	// special event: the path for the event is the original path
+	// you specified, the flag RootChanged is set and event ID is
+	// zero. RootChanged events are useful to indicate that you
+	// should rescan a particular hierarchy because it changed
+	// completely (as opposed to the things inside of it changing).
+	// If you want to track the current location of a directory, it
+	// is best to open the directory before creating the stream so
+	// that you have a file descriptor for it and can issue an
+	// F_GETPATH fcntl() to find the current path.
+	WatchRoot = CreateFlags(C.kFSEventStreamCreateFlagWatchRoot)
+
+	// IgnoreSelf doesn't send events triggered by the current process (macOS 10.6+).
+	//
+	// Don't send events that were triggered by the current process.
+	// This is useful for reducing the volume of events that are
+	// sent. It is only useful if your process might modify the file
+	// system hierarchy beneath the path(s) being monitored. Note:
+	// this has no effect on historical events, i.e., those
+	// delivered before the HistoryDone sentinel event.
+	IgnoreSelf = CreateFlags(C.kFSEventStreamCreateFlagIgnoreSelf)
+
+	// FileEvents sends events about individual files, generating significantly
+	// more events (macOS 10.7+) than directory level notifications.
+	FileEvents = CreateFlags(C.kFSEventStreamCreateFlagFileEvents)
+)
+
+
+// EventFlags passed to the FSEventStreamCallback function.
+// These correspond directly to the flags as described here:
+// https://developer.apple.com/documentation/coreservices/1455361-fseventstreameventflags
+type EventFlags uint32
+
+const (
+	// MustScanSubDirs indicates that events were coalesced hierarchically.
+	//
+	// Your application must rescan not just the directory given in
+	// the event, but all its children, recursively. This can happen
+	// if there was a problem whereby events were coalesced
+	// hierarchically. For example, an event in /Users/jsmith/Music
+	// and an event in /Users/jsmith/Pictures might be coalesced
+	// into an event with this flag set and path=/Users/jsmith. If
+	// this flag is set you may be able to get an idea of whether
+	// the bottleneck happened in the kernel (less likely) or in
+	// your client (more likely) by checking for the presence of the
+	// informational flags UserDropped or KernelDropped.
+	MustScanSubDirs EventFlags = EventFlags(C.kFSEventStreamEventFlagMustScanSubDirs)
+
+	// KernelDropped or UserDropped may be set in addition
+	// to the MustScanSubDirs flag to indicate that a problem
+	// occurred in buffering the events (the particular flag set
+	// indicates where the problem occurred) and that the client
+	// must do a full scan of any directories (and their
+	// subdirectories, recursively) being monitored by this stream.
+	// If you asked to monitor multiple paths with this stream then
+	// you will be notified about all of them. Your code need only
+	// check for the MustScanSubDirs flag; these flags (if present)
+	// only provide information to help you diagnose the problem.
+	KernelDropped = EventFlags(C.kFSEventStreamEventFlagKernelDropped)
+
+	// UserDropped is related to UserDropped above.
+	UserDropped = EventFlags(C.kFSEventStreamEventFlagUserDropped)
+
+	// EventIDsWrapped indicates the 64-bit event ID counter wrapped around.
+	//
+	// If EventIdsWrapped is set, it means
+	// the 64-bit event ID counter wrapped around. As a result,
+	// previously-issued event ID's are no longer valid
+	// for the EventID field when using EventStream.Resume.
+	EventIDsWrapped = EventFlags(C.kFSEventStreamEventFlagEventIdsWrapped)
+
+	// HistoryDone is a sentinel event when retrieving events with EventStream.Resume.
+	//
+	// Denotes a sentinel event sent to mark the end of the
+	// "historical" events sent as a result of specifying
+	// EventStream.Resume.
+	//
+	// After sending all the "historical" events that occurred before now,
+	// an event will be sent with the HistoryDone flag set. The client
+	// should ignore the path supplied in that event.
+	HistoryDone = EventFlags(C.kFSEventStreamEventFlagHistoryDone)
+
+	// RootChanged indicates a change to a directory along the path being watched.
+	//
+	// Denotes a special event sent when there is a change to one of
+	// the directories along the path to one of the directories you
+	// asked to watch. When this flag is set, the event ID is zero
+	// and the path corresponds to one of the paths you asked to
+	// watch (specifically, the one that changed). The path may no
+	// longer exist because it or one of its parents was deleted or
+	// renamed. Events with this flag set will only be sent if you
+	// passed the flag WatchRoot when you created the stream.
+	RootChanged = EventFlags(C.kFSEventStreamEventFlagRootChanged)
+
+	// Mount for a volume mounted underneath the path being monitored.
+	//
+	// Denotes a special event sent when a volume is mounted
+	// underneath one of the paths being monitored. The path in the
+	// event is the path to the newly-mounted volume. You will
+	// receive one of these notifications for every volume mount
+	// event inside the kernel (independent of DiskArbitration).
+	// Beware that a newly-mounted volume could contain an
+	// arbitrarily large directory hierarchy. Avoid pitfalls like
+	// triggering a recursive scan of a non-local filesystem, which
+	// you can detect by checking for the absence of the MNT_LOCAL
+	// flag in the f_flags returned by statfs(). Also be aware of
+	// the MNT_DONTBROWSE flag that is set for volumes which should
+	// not be displayed by user interface elements.
+	Mount = EventFlags(C.kFSEventStreamEventFlagMount)
+
+	// Unmount event occurs after a volume is unmounted.
+	//
+	// Denotes a special event sent when a volume is unmounted
+	// underneath one of the paths being monitored. The path in the
+	// event is the path to the directory from which the volume was
+	// unmounted. You will receive one of these notifications for
+	// every volume unmount event inside the kernel. This is not a
+	// substitute for the notifications provided by the
+	// DiskArbitration framework; you only get notified after the
+	// unmount has occurred. Beware that unmounting a volume could
+	// uncover an arbitrarily large directory hierarchy, although
+	// macOS never does that.
+	Unmount = EventFlags(C.kFSEventStreamEventFlagUnmount)
+
+	// The following flags are only set when using FileEvents.
+
+	// ItemCreated indicates that a file or directory has been created.
+	ItemCreated = EventFlags(C.kFSEventStreamEventFlagItemCreated)
+
+	// ItemRemoved indicates that a file or directory has been removed.
+	ItemRemoved = EventFlags(C.kFSEventStreamEventFlagItemRemoved)
+
+	// ItemInodeMetaMod indicates that a file or directory's metadata has has been modified.
+	ItemInodeMetaMod = EventFlags(C.kFSEventStreamEventFlagItemInodeMetaMod)
+
+	// ItemRenamed indicates that a file or directory has been renamed.
+	// TODO is there any indication what it might have been renamed to?
+	ItemRenamed = EventFlags(C.kFSEventStreamEventFlagItemRenamed)
+
+	// ItemModified indicates that a file has been modified.
+	ItemModified = EventFlags(C.kFSEventStreamEventFlagItemModified)
+
+	// ItemFinderInfoMod indicates the the item's Finder information has been
+	// modified.
+	// TODO the above is just a guess.
+	ItemFinderInfoMod = EventFlags(C.kFSEventStreamEventFlagItemFinderInfoMod)
+
+	// ItemChangeOwner indicates that the file has changed ownership.
+	ItemChangeOwner = EventFlags(C.kFSEventStreamEventFlagItemChangeOwner)
+
+	// ItemXattrMod indicates that the files extended attributes have changed.
+	ItemXattrMod = EventFlags(C.kFSEventStreamEventFlagItemXattrMod)
+
+	// ItemIsFile indicates that the item is a file.
+	ItemIsFile = EventFlags(C.kFSEventStreamEventFlagItemIsFile)
+
+	// ItemIsDir indicates that the item is a directory.
+	ItemIsDir = EventFlags(C.kFSEventStreamEventFlagItemIsDir)
+
+	// ItemIsSymlink indicates that the item is a symbolic link.
+	ItemIsSymlink = EventFlags(C.kFSEventStreamEventFlagItemIsSymlink)
+)
+
 // LatestEventID returns the most recently generated event ID, system-wide.
 func LatestEventID() uint64 {
 	return uint64(C.FSEventsGetCurrentEventId())
@@ -69,28 +261,28 @@ func fsevtCallback(stream C.FSEventStreamRef, info uintptr, numEvents C.size_t, 
 	es.Events <- events
 }
 
-// FSEventStreamRef wraps C.FSEventStreamRef
-type FSEventStreamRef C.FSEventStreamRef
+// fsEventStreamRef wraps C.FSEventStreamRef
+type fsEventStreamRef C.FSEventStreamRef
 
-// GetStreamRefEventID retrieves the last EventID from the ref
-func GetStreamRefEventID(f FSEventStreamRef) uint64 {
+// getStreamRefEventID retrieves the last EventID from the ref
+func getStreamRefEventID(f fsEventStreamRef) uint64 {
 	return uint64(C.FSEventStreamGetLatestEventId(f))
 }
 
-// GetStreamRefDeviceID retrieves the device ID the stream is watching
-func GetStreamRefDeviceID(f FSEventStreamRef) int32 {
+// getStreamRefDeviceID retrieves the device ID the stream is watching
+func getStreamRefDeviceID(f fsEventStreamRef) int32 {
 	return int32(C.FSEventStreamGetDeviceBeingWatched(f))
 }
 
-// GetStreamRefDescription retrieves debugging description information
+// getStreamRefDescription retrieves debugging description information
 // about the StreamRef
-func GetStreamRefDescription(f FSEventStreamRef) string {
+func getStreamRefDescription(f fsEventStreamRef) string {
 	return cfStringToGoString(C.FSEventStreamCopyDescription(f))
 }
 
-// GetStreamRefPaths returns a copy of the paths being watched by
+// getStreamRefPaths returns a copy of the paths being watched by
 // this stream
-func GetStreamRefPaths(f FSEventStreamRef) []string {
+func getStreamRefPaths(f fsEventStreamRef) []string {
 	arr := C.FSEventStreamCopyPathsBeingWatched(f)
 	l := cfArrayLen(arr)
 
@@ -140,8 +332,8 @@ func copyCFString(cfs C.CFStringRef) C.CFStringRef {
 	return C.CFStringCreateCopy(C.kCFAllocatorDefault, cfs)
 }
 
-// CFRunLoopRef wraps C.CFRunLoopRef
-type CFRunLoopRef C.CFRunLoopRef
+// cfRunLoopRef wraps C.CFRunLoopRef
+type cfRunLoopRef C.CFRunLoopRef
 
 // EventIDForDeviceBeforeTime returns an event ID before a given time.
 func EventIDForDeviceBeforeTime(dev int32, before time.Time) uint64 {
@@ -186,7 +378,7 @@ func cfArrayLen(ref C.CFArrayRef) int {
 	return int(C.CFArrayGetCount(ref))
 }
 
-func setupStream(paths []string, flags CreateFlags, callbackInfo uintptr, eventID uint64, latency time.Duration, deviceID int32) FSEventStreamRef {
+func setupStream(paths []string, flags CreateFlags, callbackInfo uintptr, eventID uint64, latency time.Duration, deviceID int32) fsEventStreamRef {
 	cPaths, err := createPaths(paths)
 	if err != nil {
 		log.Printf("Error creating paths: %s", err)
@@ -208,7 +400,7 @@ func setupStream(paths []string, flags CreateFlags, callbackInfo uintptr, eventI
 			cfinv, C.FSEventStreamCreateFlags(flags))
 	}
 
-	return FSEventStreamRef(ref)
+	return fsEventStreamRef(ref)
 }
 
 func (es *EventStream) start(paths []string, callbackInfo uintptr) {
@@ -224,7 +416,7 @@ func (es *EventStream) start(paths []string, callbackInfo uintptr) {
 
 	go func() {
 		runtime.LockOSThread()
-		es.rlref = CFRunLoopRef(C.CFRunLoopGetCurrent())
+		es.rlref = cfRunLoopRef(C.CFRunLoopGetCurrent())
 		C.CFRetain(C.CFTypeRef(es.rlref))
 		C.FSEventStreamScheduleWithRunLoop(es.stream, C.CFRunLoopRef(es.rlref), C.kCFRunLoopDefaultMode)
 		C.FSEventStreamStart(es.stream)
@@ -249,7 +441,7 @@ func finalizer(es *EventStream) {
 }
 
 // flush drains the event stream of undelivered events
-func flush(stream FSEventStreamRef, sync bool) {
+func flush(stream fsEventStreamRef, sync bool) {
 	if sync {
 		C.FSEventStreamFlushSync(stream)
 	} else {
@@ -258,7 +450,7 @@ func flush(stream FSEventStreamRef, sync bool) {
 }
 
 // stop requests fsevents stops streaming events
-func stop(stream FSEventStreamRef, rlref CFRunLoopRef) {
+func stop(stream fsEventStreamRef, rlref cfRunLoopRef) {
 	C.FSEventStreamStop(stream)
 	C.FSEventStreamInvalidate(stream)
 	C.FSEventStreamRelease(stream)

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -24,15 +24,15 @@ func TestEventStream(t *testing.T) {
 	paths := []string{"/a", "/b"}
 	ref := setupStream(paths, 0, 0, eid, time.Duration(0), did)
 
-	if e := GetStreamRefEventID(ref); eid != e {
+	if e := getStreamRefEventID(ref); eid != e {
 		t.Errorf("got: %d wanted: %d", e, eid)
 	}
 
-	if e := GetStreamRefDeviceID(ref); did != e {
+	if e := getStreamRefDeviceID(ref); did != e {
 		t.Errorf("got: %d wanted: %d", e, did)
 	}
 
-	spaths := GetStreamRefPaths(ref)
+	spaths := getStreamRefPaths(ref)
 	for i := range paths {
 		if paths[i] != spaths[i] {
 			t.Errorf("pos %d got: %s wanted: %s", i, spaths[i], paths[i])


### PR DESCRIPTION
This PR adds comprehensive doc comments to all exported
constants, mostly derived from the Apple documentation
but with changes to make them directly relevant to this package's API.

It also uses C constants directly rather than relying on an implicit
association between `1<<iota` and the actual enum values.

It also unexports `GetStreamRefPaths`, `GetStreamRefDescription`
and `GetStreamRefDeviceID`  because none of them are usable
with this package's API because there is no way to get an
`FSEventStreamRef` value because it's hidden inside an unexported
field inside the `EventStream` struct.

Also unexport the `CFRunLoopRef` because it's similarly
not useful or usable.

Other than the above unexports, the API remains identical.

Unfortunately I am unable to get the tests to pass, which
makes me think that something is wrong somewhere, but
that applies to the original code too, not just the code with
these changes applied.

#### What does this pull request do?


#### Where should the reviewer start?


#### How should this be manually tested?

