### PR TITLE
fix broken test in macOS 11.5.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,7 +11,7 @@
 Adrian Serrano <adrisr83@gmail.com>
 Andrew Metcalf <andrew@stripe.com>
 Drew Wells <drew.wells00@gmail.com>
-Jeremy Jay <pbnjay@users.noreply.github.com>
+Jeremy Jay <jeremy@pbnjay.com>
 Koichi Shiraishi <zchee.io@gmail.com>
 Lachlan Donald <lachlan@ljd.cc>
 Matthias Kadenbach <matthias@synack.com>

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -15,6 +15,10 @@ func TestBasicExample(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	path, err = filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(path)
 
 	dev, err := DeviceForPath(path)


### PR DESCRIPTION
#### What does this pull request do?

Fixes the broken (infinite wait) `TestBasicExample` test.

Not sure when the expected behavior changed (maybe due to some recent OS sandboxing changes), but I believe the watch expression was now tracking the TempDir symlink itself and so never receives the file creation event.

(Also fixes my email address from 2016)

#### Where should the reviewer start?
#### How should this be manually tested?

`go test -v .`
