### PR TITLE
apply go fmt by Go 1.18

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package main

--- a/fsevents.go
+++ b/fsevents.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 // Package fsevents provides file system notifications on macOS.

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package fsevents

--- a/go_1_10_after.go
+++ b/go_1_10_after.go
@@ -1,3 +1,4 @@
+//go:build darwin && go1.10
 // +build darwin,go1.10
 
 package fsevents

--- a/go_1_10_before.go
+++ b/go_1_10_before.go
@@ -1,3 +1,4 @@
+//go:build darwin && !go1.10
 // +build darwin,!go1.10
 
 package fsevents

--- a/go_1_9_2_after.go
+++ b/go_1_9_2_after.go
@@ -1,3 +1,4 @@
+//go:build darwin && go1.9.2
 // +build darwin,go1.9.2
 
 package fsevents

--- a/go_1_9_2_before.go
+++ b/go_1_9_2_before.go
@@ -1,3 +1,4 @@
+//go:build darwin && !go1.9.2
 // +build darwin,!go1.9.2
 
 package fsevents

--- a/wrap.go
+++ b/wrap.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package fsevents

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package fsevents


### PR DESCRIPTION
#### What does this pull request do?

apply `go fmt ./...`

#### Where should the reviewer start?

`go fmt` synchronizes `//go:build` lines with `// +build` lines from [Go 1.17](https://go.dev/doc/go1.17#gofmt)
It makes the formatted source code different from the previous one.

See also:

- https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md
- https://pkg.go.dev/go/build#hdr-Build_Constraints
- https://pkg.go.dev/cmd/go#hdr-Build_constraints

#### How should this be manually tested?

run `go fmt ./...` and check `git diff`