### PR TITLE
use FSEventStreamSetDispatchQueue instead of deprecated FSEventStreamScheduleWithRunLoop

### DIFF
--- a/fsevents.go
+++ b/fsevents.go
@@ -54,7 +54,6 @@ func DeviceForPath(path string) (int32, error) {
 //	...
 type EventStream struct {
 	stream       fsEventStreamRef
-	rlref        cfRunLoopRef
 	hasFinalizer bool
 	registryID   uintptr
 	uuid         string
@@ -164,7 +163,7 @@ func (es *EventStream) Flush(sync bool) {
 // Stop stops listening to the event stream.
 func (es *EventStream) Stop() {
 	if es.stream != nil {
-		stop(es.stream, es.rlref)
+		stop(es.stream)
 		es.stream = nil
 	}
 

--- a/fsevents.go
+++ b/fsevents.go
@@ -54,6 +54,7 @@ func DeviceForPath(path string) (int32, error) {
 //	...
 type EventStream struct {
 	stream       fsEventStreamRef
+	qref         fsDispatchQueueRef
 	hasFinalizer bool
 	registryID   uintptr
 	uuid         string
@@ -163,8 +164,9 @@ func (es *EventStream) Flush(sync bool) {
 // Stop stops listening to the event stream.
 func (es *EventStream) Stop() {
 	if es.stream != nil {
-		stop(es.stream)
+		stop(es.stream, es.qref)
 		es.stream = nil
+		es.qref = nil
 	}
 
 	// Remove eventstream from the registry

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -227,6 +227,7 @@ func TestMany(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var lock sync.Mutex
 	events := make(map[string]EventFlags, 810)
 
 	wait := make(chan struct{})
@@ -235,6 +236,8 @@ func TestMany(t *testing.T) {
 		for {
 			select {
 			case msg := <-es.Events:
+				lock.Lock()
+
 				for _, event := range msg {
 					if _, ok := events[event.Path]; !ok {
 						events[event.Path] = event.Flags
@@ -242,6 +245,8 @@ func TestMany(t *testing.T) {
 						events[event.Path] = events[event.Path].set(event.Flags)
 					}
 				}
+
+				lock.Unlock()
 			case <-time.After(3 * time.Second):
 				wait <- struct{}{}
 			}

--- a/wrap.go
+++ b/wrap.go
@@ -349,9 +349,6 @@ func copyCFString(cfs C.CFStringRef) C.CFStringRef {
 	return C.CFStringCreateCopy(C.kCFAllocatorDefault, cfs)
 }
 
-// cfRunLoopRef wraps C.CFRunLoopRef
-type cfRunLoopRef C.CFRunLoopRef
-
 // EventIDForDeviceBeforeTime returns an event ID before a given time.
 func EventIDForDeviceBeforeTime(dev int32, before time.Time) uint64 {
 	tm := C.CFAbsoluteTime(before.Unix())
@@ -429,26 +426,16 @@ func (es *EventStream) start(paths []string, callbackInfo uintptr) error {
 
 	es.stream = setupStream(paths, es.Flags, callbackInfo, since, es.Latency, es.Device)
 
-	started := make(chan error)
+	q := C.dispatch_queue_create(nil, nil)
+	C.FSEventStreamSetDispatchQueue(es.stream, q)
 
-	go func() {
-		runtime.LockOSThread()
-		es.rlref = cfRunLoopRef(C.CFRunLoopGetCurrent())
-		C.CFRetain(C.CFTypeRef(es.rlref))
-		C.FSEventStreamScheduleWithRunLoop(es.stream, C.CFRunLoopRef(es.rlref), C.kCFRunLoopDefaultMode)
-		if C.FSEventStreamStart(es.stream) == 0 {
-			// cleanup stream and runloop
-			C.FSEventStreamInvalidate(es.stream)
-			C.FSEventStreamRelease(es.stream)
-			C.CFRelease(C.CFTypeRef(es.rlref))
-			es.stream = nil
-			started <- fmt.Errorf("failed to start eventstream")
-			close(started)
-			return
-		}
-		close(started)
-		C.CFRunLoopRun()
-	}()
+	if C.FSEventStreamStart(es.stream) == 0 {
+		// cleanup stream
+		C.FSEventStreamInvalidate(es.stream)
+		C.FSEventStreamRelease(es.stream)
+		es.stream = nil
+		return fmt.Errorf("failed to start eventstream")
+	}
 
 	if !es.hasFinalizer {
 		// TODO: There is no guarantee this run before program exit
@@ -457,7 +444,7 @@ func (es *EventStream) start(paths []string, callbackInfo uintptr) error {
 		es.hasFinalizer = true
 	}
 
-	return <-started
+	return nil
 }
 
 func finalizer(es *EventStream) {
@@ -476,10 +463,8 @@ func flush(stream fsEventStreamRef, sync bool) {
 }
 
 // stop requests fsevents stops streaming events
-func stop(stream fsEventStreamRef, rlref cfRunLoopRef) {
+func stop(stream fsEventStreamRef) {
 	C.FSEventStreamStop(stream)
 	C.FSEventStreamInvalidate(stream)
 	C.FSEventStreamRelease(stream)
-	C.CFRunLoopStop(C.CFRunLoopRef(rlref))
-	C.CFRelease(C.CFTypeRef(rlref))
 }

--- a/wrap.go
+++ b/wrap.go
@@ -444,6 +444,7 @@ func (es *EventStream) start(paths []string, callbackInfo uintptr) error {
 		// cleanup stream
 		C.FSEventStreamInvalidate(es.stream)
 		C.FSEventStreamRelease(es.stream)
+		C.DispatchQueueRelease(es.qref)
 		es.stream = nil
 		es.qref = nil
 		return fmt.Errorf("failed to start eventstream")


### PR DESCRIPTION
Hello!

FSEventStreamScheduleWithRunLoop is deprecated and triggers compile warnings so I basically made this change for myself to get rid of the warning.

Wanted to open the create the PR in case this is actually a useful change to have. Feel free to close the PR if the change is not needed.

#### What does this pull request do?
Replaces the deprecated FSEventStreamScheduleWithRunLoop with the suggested FSEventStreamSetDispatchQueue.
Also removes the run loop part, as FSEventStreamSetDispatchQueue handles it itself using a separate, hidden thread.
The behavior remains the same - calling Start is non-blocking.

Helpful discussion I found on the web:
https://www.spinics.net/lists/git/msg452085.html

For FSEventStreamScheduleWithRunLoop the [docs](https://developer.apple.com/documentation/coreservices/1447824-fseventstreamschedulewithrunloop?language=objc) say:
Introduced in macOS 10.5 and deprecated in macOS 13.0

FSEventStreamSetDispatchQueue the [docs](https://developer.apple.com/documentation/coreservices/1444164-fseventstreamsetdispatchqueue?language=objc) say:
Available on macOS 10.6 and later

Seems like macOS 10.5 gets shafted by this change but only that version.

#### Where should the reviewer start?
wrap.go

The test TestBasicExample tests that the code actually works, but all the tests here are very basic, and frankly, I don't have enough understanding of this to prove this doesn't break something.

https://github.com/docker/compose has a direct dependency on fsevents, and I tried running all their tests using my fsevents code and nothing seemed to break. Not sure that the right code paths were executed though.

#### How should this be manually tested?
I do not know, to be honest. I just modified the TestBasicExample to create a bunch of files and events seemed to be emitted properly.

Have a nice day!
